### PR TITLE
Emit type declaration file and use it for "types" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tsconfig.json"
   ],
   "main": "dist/src/Signal.js",
-  "types": "src/Signal.ts",
+  "types": "dist/src/Signal.d.ts",
   "scripts": {
     "pretest": "tsc",
     "test": "nyc mocha --require source-map-support/register \"./dist/test/**/*.js\"",

--- a/src/Signal.ts
+++ b/src/Signal.ts
@@ -136,7 +136,7 @@ export class Signal<CB extends Function> {
      * Create a new signal.
      */
     public constructor() {
-        (this as any).emit = this.emitInternal.bind(this);
+        this.emit = this.emitInternal.bind(this);
     }
 
     /**
@@ -219,7 +219,7 @@ export abstract class Collector<CB extends Function, RT> {
      */
     public constructor(signal: Signal<CB>) {
         let self = this;
-        (this as any).emit = function () { (signal as any).emitCollecting(self, arguments); };
+        this.emit = function () { (signal as any).emitCollecting(self, arguments); } as any;
     }
 
     /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     ],
     "sourceMap": true,
     "outDir": "./dist",
+    "declaration": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,


### PR DESCRIPTION
As @timocov pointed out on https://github.com/timocov/dts-bundle-generator/issues/53, the package.json file of this project references "Signal.ts", which contains both TypeScript declarations and definitions. The file should however only contain the declarations. This pull request makes TS create a Signal.d.ts file and it fixes compilation with TypeScript 2.9.2.