### PR TITLE
fix connection count on SignalConnection disconnect

### DIFF
--- a/src/Signal.ts
+++ b/src/Signal.ts
@@ -43,7 +43,11 @@ export class Signal<THandler extends (...args: any[]) => any> {
             this.hasNewLinks = true;
             link.newLink = true;
         }
-        return new SignalConnectionImpl(link);
+        return new SignalConnectionImpl(link, () => this.decrementConnectionCount());
+    }
+
+    private decrementConnectionCount() {
+        this.connectionsCount--;
     }
 
     /**
@@ -55,7 +59,7 @@ export class Signal<THandler extends (...args: any[]) => any> {
     public disconnect(callback: THandler) {
         for (let link = this.head.next; link !== this.head; link = link.next) {
             if (link.callback === callback) {
-                this.connectionsCount--;
+                this.decrementConnectionCount();
                 link.unlink();
                 return true;
             }

--- a/src/SignalConnection.spec.ts
+++ b/src/SignalConnection.spec.ts
@@ -1,0 +1,36 @@
+import {Signal} from "./Signal";
+import {Dummy, ListenerMock} from "./testUtils";
+
+describe("SignalConnection", () => {
+    describe("when disconnecting", () => {
+        it("should update the connection count of the parent Signal", () => {
+            const signal = new Signal<(d: Dummy) => void>();
+            const connections = [];
+
+            expect(signal.getConnectionsCount()).toBe(0);
+            expect(signal.hasConnections()).toBe(false);
+
+            let listener = new ListenerMock();
+            connections.push(signal.connect(listener.callback));
+
+            expect(signal.getConnectionsCount()).toBe(1);
+            expect(signal.hasConnections()).toBe(true);
+
+            listener = new ListenerMock();
+            connections.push(signal.connect(listener.callback));
+
+            expect(signal.getConnectionsCount()).toBe(2);
+            expect(signal.hasConnections()).toBe(true);
+
+            connections.pop()!.disconnect();
+
+            expect(signal.getConnectionsCount()).toBe(1);
+            expect(signal.hasConnections()).toBe(true);
+
+            connections.pop()!.disconnect();
+
+            expect(signal.getConnectionsCount()).toBe(0);
+            expect(signal.hasConnections()).toBe(false);
+        });
+    });
+});

--- a/src/SignalConnection.ts
+++ b/src/SignalConnection.ts
@@ -23,19 +23,24 @@ export interface SignalConnection {
  */
 export class SignalConnectionImpl<THandler extends (...args: any[]) => any> implements SignalConnection {
     private link: SignalLink<THandler> | null;
+    private parentCleanup: {() : void} | null;
 
     /**
-     * @param head The head link of the signal.
      * @param link The actual link of the connection.
+     * @param parentCleanup Callback to cleanup the parent signal when a connection is disconnected
      */
-    public constructor(link: SignalLink<THandler>) {
+    public constructor(link: SignalLink<THandler>, parentCleanup: () => void) {
         this.link = link;
+        this.parentCleanup = parentCleanup;
     }
 
     public disconnect(): boolean {
         if (this.link !== null) {
             this.link.unlink();
             this.link = null;
+
+            this.parentCleanup!();
+            this.parentCleanup = null;
             return true;
         }
 


### PR DESCRIPTION
The connection count doesn't decrement when calling `disconnect()` on a `SignalConnection`. Let me know if you'd like it implemented differently, happy to amend.