### PR TITLE
Restrict disconnect all

### DIFF
--- a/src/Signal.spec.ts
+++ b/src/Signal.spec.ts
@@ -198,6 +198,26 @@ describe("Signal", () => {
         expect(count2).toBe(1);
     });
 
+    it("should prevent disconnecting private listeners", () => {
+        const sig = new Signal<() => void>();
+        let count1 = 0;
+        let count2 = 0;
+        const connection1 = sig.connect(() => count1++, { isPublic: false });
+        sig.connect(() => count2++);
+        sig.emit();
+        expect(count1).toBe(1);
+        expect(count2).toBe(1);
+        sig.disconnectAll();
+        sig.emit();
+        expect(count1).toBe(2);
+        expect(count2).toBe(1);
+        // should still allow disconnecting the connection manually
+        connection1.disconnect();
+        sig.emit();
+        expect(count1).toBe(2);
+        expect(count2).toBe(1);
+    });
+
     it("should allow disconnecting one listener", () => {
         const sig = new Signal<() => void>();
         let count1 = 0;
@@ -294,10 +314,10 @@ describe("Signal", () => {
             const d = new ListenerPriorityMock(3);
 
             const signal = new Signal<() => void>();
-            signal.connect(d.callback, 3);
-            signal.connect(a.callback, 0);
-            signal.connect(c.callback, 2);
-            signal.connect(b.callback, 1);
+            signal.connect(d.callback, { order: 3 });
+            signal.connect(a.callback, { order: 0 });
+            signal.connect(c.callback, { order: 2 });
+            signal.connect(b.callback, { order: 1 });
 
             signal.emit();
             expect(a.testCallback).toHaveBeenCalledTimes(1);

--- a/src/Signal.ts
+++ b/src/Signal.ts
@@ -6,6 +6,16 @@ import { SignalLink } from "./SignalLink";
 const headOptions = { order: 0, isPublic: true, onUnlink() {} } as const;
 
 /**
+ * Options for the connect method
+ */
+export type ConnectOptions = {
+    /** Handlers with a higher order value will be called later. */
+    order?: number;
+    /** Handlers with isPublic=false will not be removed when signal.disconnectAll is called. Disconnect manually or via SignalConnections */
+    isPublic?: boolean;
+};
+
+/**
  * A signal is a way to publish and subscribe to events.
  *
  * @typeparam THandler The function signature to be implemented by handlers.
@@ -37,10 +47,9 @@ export class Signal<THandler extends (...args: any[]) => any> {
      * Subscribe to this signal.
      *
      * @param callback This callback will be run when emit() is called.
-     * @param order Handlers with a higher order value will be called later.
-     * @param isPublic Handlers with isPublic=false will not be removed when signal.disconnectAll is called. Disconnect manually or via SignalConnections
+     * @param options Configure options for the connection
      */
-    public connect(callback: THandler, order = 0, isPublic = true): SignalConnection {
+    public connect(callback: THandler, { order = 0, isPublic = true }: ConnectOptions = {}): SignalConnection {
         this.connectionsCount++;
         const link = this.head.insert({ callback, order, isPublic, onUnlink: this.onUnlink });
         if (this.emitDepth > 0) {

--- a/src/SignalConnection.ts
+++ b/src/SignalConnection.ts
@@ -22,39 +22,24 @@ export interface SignalConnection {
  * @private
  */
 export class SignalConnectionImpl<THandler extends (...args: any[]) => any> implements SignalConnection {
-    private link: SignalLink<THandler> | null;
-
-    private parentCleanup: { (): void } | null;
+    private link: SignalLink<THandler>;
 
     /**
      * @param link The actual link of the connection.
-     * @param parentCleanup Callback to cleanup the parent signal when a connection is disconnected
      */
-    public constructor(link: SignalLink<THandler>, parentCleanup: () => void) {
+    public constructor(link: SignalLink<THandler>) {
         this.link = link;
-        this.parentCleanup = parentCleanup;
     }
 
     public disconnect(): boolean {
-        if (this.link !== null) {
-            this.link.unlink();
-            this.link = null;
-
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            this.parentCleanup!();
-            this.parentCleanup = null;
-            return true;
-        }
-
-        return false;
+        return this.link.unlink();
     }
 
     public set enabled(enable: boolean) {
-        if (this.link) this.link.setEnabled(enable);
+        this.link.setEnabled(enable);
     }
 
     public get enabled(): boolean {
-        // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
-        return this.link !== null && this.link.isEnabled();
+        return this.link.isEnabled();
     }
 }

--- a/src/SignalLink.ts
+++ b/src/SignalLink.ts
@@ -1,5 +1,6 @@
 type SignalLinkOptions<THandler extends (...args: any[]) => any> = {
     order: number;
+    isPublic: boolean;
     onUnlink(): void;
     callback?: THandler;
 };
@@ -21,6 +22,8 @@ export class SignalLink<THandler extends (...args: any[]) => any> {
 
     public callback?: THandler;
 
+    public readonly isPublic: boolean;
+
     private onUnlink: () => void;
 
     public constructor(
@@ -31,6 +34,7 @@ export class SignalLink<THandler extends (...args: any[]) => any> {
         this.prev = prev ?? this;
         this.next = next ?? this;
         this.order = options.order;
+        this.isPublic = options.isPublic;
         this.callback = options.callback;
         this.onUnlink = options.onUnlink;
     }


### PR DESCRIPTION
Resolves #13

First idea. Needs tests and documentation. I'm also not decided on the naming.

@minitoine please check if this API would fit your needs. Check https://github.com/Lusito/typed-signals/commit/b1d99088893439e1fe2b9efe4584e57664fc4fe7 for relevant changes.

Essentially, you'd write `connect(myCallback, 0, false)` to prevent a callback from being removed via `signal.disconnectAll`

disconnecting via `SignalConnection` or `SignalConnections` would still work.

Ideally, the API would be more speaking, for example:
```ts
connect(myCallback, { order: 0, isPublic: false });
```

But this would be a breaking change. Maybe I'll take some time to think about possible changes for the next version before I create these kinds of breaking changes.